### PR TITLE
Slot react component

### DIFF
--- a/.changeset/short-tables-dress.md
+++ b/.changeset/short-tables-dress.md
@@ -1,0 +1,7 @@
+---
+"@backflipjs/client": patch
+"@backflipjs/server": patch
+"@backflipjs/react": patch
+---
+
+Add Slot component to @backflipjs/react

--- a/examples/expo/app/index.tsx
+++ b/examples/expo/app/index.tsx
@@ -1,6 +1,7 @@
 import {
   RenderComponent,
   type RenderedComponentConfig,
+  Slot,
 } from "@backflipjs/react";
 
 import { Button } from "../components/button";
@@ -46,6 +47,10 @@ export default function HomeScreen() {
           <DateTime.Skeleton />
         </Container>
       }
-    />
+    >
+      <Slot name="footer">
+        <Text content="This is the footer" />
+      </Slot>
+    </RenderComponent>
   );
 }

--- a/examples/expo/components/container.tsx
+++ b/examples/expo/components/container.tsx
@@ -1,3 +1,4 @@
+import { Slot } from "@backflipjs/react";
 import { styled } from "nativewind";
 import { View } from "react-native";
 
@@ -10,6 +11,7 @@ export function Container({ children }: React.PropsWithChildren) {
       style={{ gap: 16 }}
     >
       {children}
+      <Slot name="footer" />
     </StyledView>
   );
 }

--- a/examples/expo/package.json
+++ b/examples/expo/package.json
@@ -23,13 +23,13 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.73.1",
-    "react-native-safe-area-context": "4.8.2",
-    "react-native-screens": "~3.29.0",
+    "react-native-safe-area-context": "4.7.4",
+    "react-native-screens": "~3.27.0",
     "react-native-web": "~0.19.10"
   },
   "devDependencies": {
     "@babel/core": "~7.23.7",
     "@types/react": "~18.2.46",
-    "tailwindcss": "3.4.0"
+    "tailwindcss": "3.3.2"
   }
 }

--- a/examples/remix/app/components/container.tsx
+++ b/examples/remix/app/components/container.tsx
@@ -1,7 +1,10 @@
+import { Slot } from "@backflipjs/react";
+
 export function Container({ children }: React.PropsWithChildren) {
   return (
     <div className="flex flex-col gap-4 justify-center items-center h-full w-full">
       {children}
+      <Slot name="footer" />
     </div>
   );
 }

--- a/examples/remix/app/routes/_index.tsx
+++ b/examples/remix/app/routes/_index.tsx
@@ -1,6 +1,7 @@
 import {
   RenderComponent,
   type RenderedComponentConfig,
+  Slot,
 } from "@backflipjs/react";
 
 import { Button } from "~/components/button";
@@ -46,6 +47,10 @@ export default function Home() {
           <DateTime.Skeleton />
         </Container>
       }
-    />
+    >
+      <Slot name="footer">
+        <Text content="This is the footer" />
+      </Slot>
+    </RenderComponent>
   );
 }

--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -16,7 +16,7 @@
     "@remix-run/node": "~2.4.1",
     "@remix-run/react": "~2.4.1",
     "@remix-run/serve": "~2.4.1",
-    "isbot": "~4.1.0",
+    "isbot": "3.8.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0"
   },

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
   "author": "samuel.laycock@cloudmix.dev",
   "license": "MIT",
   "dependencies": {
-    "superjson": "~2.2.1"
+    "superjson": "1.13.3"
   },
   "devDependencies": {
     "@backflipjs/server": "workspace:~0.0.6",

--- a/packages/react/src/components/provider.tsx
+++ b/packages/react/src/components/provider.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 
 import { Context } from "../contexts/context";
 
-interface ProviderProps {
+export interface ProviderProps {
   client: Client;
   devMode?: boolean;
   registry: Registry;

--- a/packages/react/src/components/slot.tsx
+++ b/packages/react/src/components/slot.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { useSlot } from "../hooks/use-slot";
+
+export interface SlotProps {
+  name: string;
+  children?: React.ReactNode | React.ReactNode[];
+}
+
+export function Slot({ children, name }: SlotProps) {
+  const { slots, setSlot } = useSlot();
+  const toRender = !children ? slots[name] ?? null : children;
+
+  useEffect(() => {
+    if (children && slots[name] !== children) {
+      setSlot(name, children);
+    }
+  }, [name, children, slots, setSlot]);
+
+  return <>{toRender}</>;
+}

--- a/packages/react/src/contexts/slot.ts
+++ b/packages/react/src/contexts/slot.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+export const SlotContext = createContext<{
+  slots: Record<string, React.ReactNode | React.ReactNode[]>;
+  setSlot: (
+    name: string,
+    children: React.ReactNode | React.ReactNode[],
+  ) => void;
+}>({ slots: {}, setSlot: () => {} });

--- a/packages/react/src/hooks/use-context.ts
+++ b/packages/react/src/hooks/use-context.ts
@@ -1,9 +1,9 @@
-import * as React from "react";
+import { useContext as baseUseContext } from "react";
 
 import { Context } from "../contexts/context";
 
 export function useContext() {
-  const context = React.useContext(Context);
+  const context = baseUseContext(Context);
 
   if (!context) {
     throw new Error("BackflipContext is not defined");

--- a/packages/react/src/hooks/use-slot.ts
+++ b/packages/react/src/hooks/use-slot.ts
@@ -1,0 +1,7 @@
+import { useContext } from "react";
+
+import { SlotContext } from "../contexts/slot";
+
+export function useSlot() {
+  return useContext(SlotContext);
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,8 +6,12 @@ import {
   type RenderedComponentConfig,
 } from "@backflipjs/client";
 
-import { Provider } from "./components/provider";
-import { RenderComponent } from "./components/render-component";
+import { Provider, type ProviderProps } from "./components/provider";
+import {
+  RenderComponent,
+  type RenderContentProps,
+} from "./components/render-component";
+import { Slot, type SlotProps } from "./components/slot";
 import { Registry } from "./registry";
 
 export {
@@ -16,7 +20,11 @@ export {
   Provider,
   Registry,
   RenderComponent,
+  Slot,
   type ClientOptions,
   type ClientSendOptions,
   type RenderedComponentConfig,
+  type RenderContentProps,
+  type ProviderProps,
+  type SlotProps,
 };

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -25,7 +25,7 @@
   },
   "keywords": ["backflipjs", "server"],
   "dependencies": {
-    "superjson": "~2.2.1"
+    "superjson": "1.13.3"
   },
   "devDependencies": {
     "vite-plugin-dts": "~3.7.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,13 +61,13 @@ importers:
         version: 6.2.1(expo@50.0.0-preview.7)
       expo-router:
         specifier: ~3.4.1
-        version: 3.4.1(expo-constants@15.4.2)(expo-linking@6.2.1)(expo-modules-autolinking@1.5.1)(expo-status-bar@1.11.1)(expo@50.0.0-preview.7)(react-dom@18.2.0)(react-native-safe-area-context@4.8.2)(react-native-screens@3.29.0)(react-native@0.73.1)(react@18.2.0)
+        version: 3.4.1(expo-constants@15.4.2)(expo-linking@6.2.1)(expo-modules-autolinking@1.5.1)(expo-status-bar@1.11.1)(expo@50.0.0-preview.7)(react-dom@18.2.0)(react-native-safe-area-context@4.7.4)(react-native-screens@3.27.0)(react-native@0.73.1)(react@18.2.0)
       expo-status-bar:
         specifier: ~1.11.1
         version: 1.11.1
       nativewind:
         specifier: ~2.0.11
-        version: 2.0.11(react@18.2.0)(tailwindcss@3.4.0)
+        version: 2.0.11(react@18.2.0)(tailwindcss@3.3.2)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -78,11 +78,11 @@ importers:
         specifier: 0.73.1
         version: 0.73.1(@babel/core@7.23.7)(@babel/preset-env@7.23.7)(react@18.2.0)
       react-native-safe-area-context:
-        specifier: 4.8.2
-        version: 4.8.2(react-native@0.73.1)(react@18.2.0)
+        specifier: 4.7.4
+        version: 4.7.4(react-native@0.73.1)(react@18.2.0)
       react-native-screens:
-        specifier: ~3.29.0
-        version: 3.29.0(react-native@0.73.1)(react@18.2.0)
+        specifier: ~3.27.0
+        version: 3.27.0(react-native@0.73.1)(react@18.2.0)
       react-native-web:
         specifier: ~0.19.10
         version: 0.19.10(react-dom@18.2.0)(react@18.2.0)
@@ -94,8 +94,8 @@ importers:
         specifier: ~18.2.46
         version: 18.2.46
       tailwindcss:
-        specifier: 3.4.0
-        version: 3.4.0
+        specifier: 3.3.2
+        version: 3.3.2
 
   examples/remix:
     dependencies:
@@ -121,8 +121,8 @@ importers:
         specifier: ~2.4.1
         version: 2.4.1(typescript@5.3.3)
       isbot:
-        specifier: ~4.1.0
-        version: 4.1.0
+        specifier: 3.8.0
+        version: 3.8.0
       react:
         specifier: ~18.2.0
         version: 18.2.0
@@ -159,8 +159,8 @@ importers:
   packages/client:
     dependencies:
       superjson:
-        specifier: ~2.2.1
-        version: 2.2.1
+        specifier: 1.13.3
+        version: 1.13.3
     devDependencies:
       '@backflipjs/server':
         specifier: workspace:~0.0.6
@@ -207,8 +207,8 @@ importers:
   packages/server:
     dependencies:
       superjson:
-        specifier: ~2.2.1
-        version: 2.2.1
+        specifier: 1.13.3
+        version: 1.13.3
     devDependencies:
       vite-plugin-dts:
         specifier: ~3.7.0
@@ -442,7 +442,7 @@ packages:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.19.0
+      '@babel/types': 7.23.6
     dev: false
 
   /@babel/helper-module-imports@7.22.15:
@@ -3326,7 +3326,7 @@ packages:
       getenv: 1.0.0
       glob: 7.1.6
       resolve-from: 5.0.0
-      semver: 7.5.3
+      semver: 7.5.4
       slash: 3.0.0
       xcode: 3.0.1
       xml2js: 0.6.0
@@ -3408,7 +3408,7 @@ packages:
       '@expo/bunyan': 4.0.0
       '@expo/metro-config': 0.10.7
       '@expo/osascript': 2.0.33
-      '@expo/spawn-async': 1.5.0
+      '@expo/spawn-async': 1.7.2
       body-parser: 1.20.2
       chalk: 4.1.2
       connect: 3.7.0
@@ -3596,7 +3596,7 @@ packages:
     resolution: {integrity: sha512-FQinlwHrTlJbntp8a7NAlCKedVXe06Va/0DSLXRO8lZVtgbEMrYYSUZWQNcOlNtc58c2elNph6z9dMOYwSo3JQ==}
     engines: {node: '>=12'}
     dependencies:
-      '@expo/spawn-async': 1.5.0
+      '@expo/spawn-async': 1.7.2
       exec-async: 2.2.0
     dev: false
 
@@ -3604,7 +3604,7 @@ packages:
     resolution: {integrity: sha512-JI9XzrxB0QVXysyuJ996FPCJGDCYRkbUvgG4QmMTTMFA1T+mv8YzazC3T9C1pHQUAAveVCre1+Pqv0nZXN24Xg==}
     dependencies:
       '@expo/json-file': 8.2.37
-      '@expo/spawn-async': 1.5.0
+      '@expo/spawn-async': 1.7.2
       ansi-regex: 5.0.1
       chalk: 4.1.2
       find-up: 5.0.0
@@ -5313,7 +5313,7 @@ packages:
       react-native: 0.73.1(@babel/core@7.23.7)(@babel/preset-env@7.23.7)(react@18.2.0)
     dev: false
 
-  /@react-navigation/bottom-tabs@6.5.11(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.8.2)(react-native-screens@3.29.0)(react-native@0.73.1)(react@18.2.0):
+  /@react-navigation/bottom-tabs@6.5.11(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.7.4)(react-native-screens@3.27.0)(react-native@0.73.1)(react@18.2.0):
     resolution: {integrity: sha512-CBN/NOdxnMvmjw+AJQI1kltOYaClTZmGec5pQ3ZNTPX86ytbIOylDIITKMfTgHZcIEFQDymx1SHeS++PIL3Szw==}
     peerDependencies:
       '@react-navigation/native': ^6.0.0
@@ -5322,13 +5322,13 @@ packages:
       react-native-safe-area-context: '>= 3.0.0'
       react-native-screens: '>= 3.0.0'
     dependencies:
-      '@react-navigation/elements': 1.3.21(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.8.2)(react-native@0.73.1)(react@18.2.0)
+      '@react-navigation/elements': 1.3.21(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.7.4)(react-native@0.73.1)(react@18.2.0)
       '@react-navigation/native': 6.1.9(react-native@0.73.1)(react@18.2.0)
       color: 4.2.3
       react: 18.2.0
       react-native: 0.73.1(@babel/core@7.23.7)(@babel/preset-env@7.23.7)(react@18.2.0)
-      react-native-safe-area-context: 4.8.2(react-native@0.73.1)(react@18.2.0)
-      react-native-screens: 3.29.0(react-native@0.73.1)(react@18.2.0)
+      react-native-safe-area-context: 4.7.4(react-native@0.73.1)(react@18.2.0)
+      react-native-screens: 3.27.0(react-native@0.73.1)(react@18.2.0)
       warn-once: 0.1.1
     dev: false
 
@@ -5346,7 +5346,7 @@ packages:
       use-latest-callback: 0.1.9(react@18.2.0)
     dev: false
 
-  /@react-navigation/elements@1.3.21(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.8.2)(react-native@0.73.1)(react@18.2.0):
+  /@react-navigation/elements@1.3.21(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.7.4)(react-native@0.73.1)(react@18.2.0):
     resolution: {integrity: sha512-eyS2C6McNR8ihUoYfc166O1D8VYVh9KIl0UQPI8/ZJVsStlfSTgeEEh+WXge6+7SFPnZ4ewzEJdSAHH+jzcEfg==}
     peerDependencies:
       '@react-navigation/native': ^6.0.0
@@ -5357,10 +5357,10 @@ packages:
       '@react-navigation/native': 6.1.9(react-native@0.73.1)(react@18.2.0)
       react: 18.2.0
       react-native: 0.73.1(@babel/core@7.23.7)(@babel/preset-env@7.23.7)(react@18.2.0)
-      react-native-safe-area-context: 4.8.2(react-native@0.73.1)(react@18.2.0)
+      react-native-safe-area-context: 4.7.4(react-native@0.73.1)(react@18.2.0)
     dev: false
 
-  /@react-navigation/native-stack@6.9.17(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.8.2)(react-native-screens@3.29.0)(react-native@0.73.1)(react@18.2.0):
+  /@react-navigation/native-stack@6.9.17(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.7.4)(react-native-screens@3.27.0)(react-native@0.73.1)(react@18.2.0):
     resolution: {integrity: sha512-X8p8aS7JptQq7uZZNFEvfEcPf6tlK4PyVwYDdryRbG98B4bh2wFQYMThxvqa+FGEN7USEuHdv2mF0GhFKfX0ew==}
     peerDependencies:
       '@react-navigation/native': ^6.0.0
@@ -5369,12 +5369,12 @@ packages:
       react-native-safe-area-context: '>= 3.0.0'
       react-native-screens: '>= 3.0.0'
     dependencies:
-      '@react-navigation/elements': 1.3.21(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.8.2)(react-native@0.73.1)(react@18.2.0)
+      '@react-navigation/elements': 1.3.21(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.7.4)(react-native@0.73.1)(react@18.2.0)
       '@react-navigation/native': 6.1.9(react-native@0.73.1)(react@18.2.0)
       react: 18.2.0
       react-native: 0.73.1(@babel/core@7.23.7)(@babel/preset-env@7.23.7)(react@18.2.0)
-      react-native-safe-area-context: 4.8.2(react-native@0.73.1)(react@18.2.0)
-      react-native-screens: 3.29.0(react-native@0.73.1)(react@18.2.0)
+      react-native-safe-area-context: 4.7.4(react-native@0.73.1)(react@18.2.0)
+      react-native-screens: 3.27.0(react-native@0.73.1)(react@18.2.0)
       warn-once: 0.1.1
     dev: false
 
@@ -8990,7 +8990,7 @@ packages:
       invariant: 2.2.4
     dev: false
 
-  /expo-router@3.4.1(expo-constants@15.4.2)(expo-linking@6.2.1)(expo-modules-autolinking@1.5.1)(expo-status-bar@1.11.1)(expo@50.0.0-preview.7)(react-dom@18.2.0)(react-native-safe-area-context@4.8.2)(react-native-screens@3.29.0)(react-native@0.73.1)(react@18.2.0):
+  /expo-router@3.4.1(expo-constants@15.4.2)(expo-linking@6.2.1)(expo-modules-autolinking@1.5.1)(expo-status-bar@1.11.1)(expo@50.0.0-preview.7)(react-dom@18.2.0)(react-native-safe-area-context@4.7.4)(react-native-screens@3.27.0)(react-native@0.73.1)(react@18.2.0):
     resolution: {integrity: sha512-Fllehb0JFiU1lfOt93aSbaWabhqlZsf/9atO4sSUtOYyy35j8/t9+64UdiyK8M9iazmQo954cPgRrkbHr75SFw==}
     peerDependencies:
       '@react-navigation/drawer': ^6.5.8
@@ -9013,17 +9013,17 @@ packages:
       '@expo/metro-runtime': 3.1.0(react-native@0.73.1)
       '@expo/server': 0.3.0
       '@radix-ui/react-slot': 1.0.1(react@18.2.0)
-      '@react-navigation/bottom-tabs': 6.5.11(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.8.2)(react-native-screens@3.29.0)(react-native@0.73.1)(react@18.2.0)
+      '@react-navigation/bottom-tabs': 6.5.11(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.7.4)(react-native-screens@3.27.0)(react-native@0.73.1)(react@18.2.0)
       '@react-navigation/native': 6.1.9(react-native@0.73.1)(react@18.2.0)
-      '@react-navigation/native-stack': 6.9.17(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.8.2)(react-native-screens@3.29.0)(react-native@0.73.1)(react@18.2.0)
+      '@react-navigation/native-stack': 6.9.17(@react-navigation/native@6.1.9)(react-native-safe-area-context@4.7.4)(react-native-screens@3.27.0)(react-native@0.73.1)(react@18.2.0)
       expo: 50.0.0-preview.7(@babel/core@7.23.7)(@react-native/babel-preset@0.74.0)
       expo-constants: 15.4.2(expo@50.0.0-preview.7)
       expo-linking: 6.2.1(expo@50.0.0-preview.7)
       expo-splash-screen: 0.26.1(expo-modules-autolinking@1.5.1)(expo@50.0.0-preview.7)
       expo-status-bar: 1.11.1
       react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
-      react-native-safe-area-context: 4.8.2(react-native@0.73.1)(react@18.2.0)
-      react-native-screens: 3.29.0(react-native@0.73.1)(react@18.2.0)
+      react-native-safe-area-context: 4.7.4(react-native@0.73.1)(react@18.2.0)
+      react-native-screens: 3.27.0(react-native@0.73.1)(react@18.2.0)
       schema-utils: 4.2.0
     transitivePeerDependencies:
       - encoding
@@ -10396,6 +10396,11 @@ packages:
   /isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
+
+  /isbot@3.8.0:
+    resolution: {integrity: sha512-vne1mzQUTR+qsMLeCBL9+/tgnDXRyc2pygLGl/WsgA+EZKIiB5Ehu0CiVTHIIk30zhJ24uGz4M5Ppse37aR0Hg==}
+    engines: {node: '>=12'}
+    dev: false
 
   /isbot@4.1.0:
     resolution: {integrity: sha512-Kz7zk1wc0oC0FYLYtqea1RKdEX4XGlqacPhoaq9HSEQamEXQNJ/MzVzBKAQXDCCHO0h/eo4CdZs9t3Jfbup5Aw==}
@@ -12396,7 +12401,7 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  /nativewind@2.0.11(react@18.2.0)(tailwindcss@3.4.0):
+  /nativewind@2.0.11(react@18.2.0)(tailwindcss@3.3.2):
     resolution: {integrity: sha512-qCEXUwKW21RYJ33KRAJl3zXq2bCq82WoI564fI21D/TiqhfmstZOqPN53RF8qK1NDK6PGl56b2xaTxgObEePEg==}
     engines: {node: '>=14.18'}
     peerDependencies:
@@ -12414,7 +12419,7 @@ packages:
       postcss-css-variables: 0.18.0(postcss@8.4.32)
       postcss-nested: 5.0.6(postcss@8.4.32)
       react-is: 18.2.0
-      tailwindcss: 3.4.0
+      tailwindcss: 3.3.2
       use-sync-external-store: 1.2.0(react@18.2.0)
     transitivePeerDependencies:
       - react
@@ -13525,8 +13530,8 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: false
 
-  /react-native-safe-area-context@4.8.2(react-native@0.73.1)(react@18.2.0):
-    resolution: {integrity: sha512-ffUOv8BJQ6RqO3nLml5gxJ6ab3EestPiyWekxdzO/1MQ7NF8fW1Mzh1C5QE9yq573Xefnc7FuzGXjtesZGv7cQ==}
+  /react-native-safe-area-context@4.7.4(react-native@0.73.1)(react@18.2.0):
+    resolution: {integrity: sha512-3LR3DCq9pdzlbq6vsHGWBFehXAKDh2Ljug6jWhLWs1QFuJHM6AS2+mH2JfKlB2LqiSFZOBcZfHQFz0sGaA3uqg==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -13535,8 +13540,8 @@ packages:
       react-native: 0.73.1(@babel/core@7.23.7)(@babel/preset-env@7.23.7)(react@18.2.0)
     dev: false
 
-  /react-native-screens@3.29.0(react-native@0.73.1)(react@18.2.0):
-    resolution: {integrity: sha512-yB1GoAMamFAcYf4ku94uBPn0/ani9QG7NdI98beJ5cet2YFESYYzuEIuU+kt+CNRcO8qqKeugxlfgAa3HyTqlg==}
+  /react-native-screens@3.27.0(react-native@0.73.1)(react@18.2.0):
+    resolution: {integrity: sha512-FzSUygZ7yLQyhDJZsl7wU68LwRpVtVdqOPWribmEU3Tf26FohFGGcfJx1D8lf2V2Teb8tI+IaLnXCKbyh2xffA==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -14756,9 +14761,9 @@ packages:
     resolution: {integrity: sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==}
     dev: false
 
-  /superjson@2.2.1:
-    resolution: {integrity: sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==}
-    engines: {node: '>=16'}
+  /superjson@1.13.3:
+    resolution: {integrity: sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==}
+    engines: {node: '>=10'}
     dependencies:
       copy-anything: 3.0.5
     dev: false
@@ -14800,6 +14805,37 @@ packages:
       '@babel/runtime': 7.23.7
     dev: false
 
+  /tailwindcss@3.3.2:
+    resolution: {integrity: sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.5.3
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.2
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.0
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.32
+      postcss-import: 15.1.0(postcss@8.4.32)
+      postcss-js: 4.0.1(postcss@8.4.32)
+      postcss-load-config: 4.0.2(postcss@8.4.32)
+      postcss-nested: 6.0.1(postcss@8.4.32)
+      postcss-selector-parser: 6.0.15
+      postcss-value-parser: 4.2.0
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+
   /tailwindcss@3.4.0:
     resolution: {integrity: sha512-VigzymniH77knD1dryXbyxR+ePHihHociZbXnLZHUyzf2MMs2ZVqlUrZ3FvpXP8pno9JzmILt1sZPD19M3IxtA==}
     engines: {node: '>=14.0.0'}
@@ -14829,6 +14865,7 @@ packages:
       sucrase: 3.35.0
     transitivePeerDependencies:
       - ts-node
+    dev: true
 
   /tar-fs@2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}


### PR DESCRIPTION
This PR adds a new `<Slot />` component to the `@backflipjs/react` package. This allows the client to render children inside a server controlled `component` **without** the server needing to send down a config for it.

Closes #17 